### PR TITLE
README: ANSI C -> C99

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libart [![Build Status](https://travis-ci.org/armon/libart.png)](https://travis-ci.org/armon/libart)
 =========
 
-This library provides an ANSI C implementation of the Adaptive Radix
+This library provides a C99 implementation of the Adaptive Radix
 Tree or ART. The ART operates similar to a traditional radix tree but
 avoids the wasted space of internal nodes by changing the node size.
 It makes use of 4 node sizes (4, 16, 48, 256), and can guarentee that


### PR DESCRIPTION
If you try to compile this with a pre-C99 compiler, or a newer compiler in C89 mode, it will choke on the C99 / C++ -style comments, among other things.
