### PR TITLE
Avoid unnecessary node48 scan

### DIFF
--- a/src/art.c
+++ b/src/art.c
@@ -351,8 +351,7 @@ static void add_child256(art_node256 *n, art_node **ref, unsigned char c, void *
 
 static void add_child48(art_node48 *n, art_node **ref, unsigned char c, void *child) {
     if (n->n.num_children < 48) {
-        int pos = 0;
-        while (n->children[pos]) pos++;
+        int pos = n->n.num_children;
         n->children[pos] = child;
         n->keys[c] = pos + 1;
         n->n.num_children++;


### PR DESCRIPTION
In the in-place insertion branch of `add_child48`, the code currently scans `children` for the first available position. But since the children of a node48 are contiguous, this is unnecessary; the first available position will always be at `num_children`.