### PR TITLE
fix travis: add /usr/local prefix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,11 +1,18 @@
 import os
 
-env_with_err = Environment(CCFLAGS = '-g -std=c99 -D_GNU_SOURCE -Wall -Werror -O3 -pthread -Isrc/')
-
-# Copy the CC environment variable
+# assume check was installed into /usr/local/
+env_with_err = Environment(
+	ENV = os.environ,
+	CPPPATH = ['#/src', '/usr/local/include'])
 if "CC" in os.environ:
-    env_with_err["CC"] = os.environ["CC"]
+	env_with_err["CC"] = os.environ["CC"]
+if "CCFLAGS" not in os.environ:
+	env_with_err["CCFLAGS"] = '-g -std=c99 -D_GNU_SOURCE -Wall -Werror -O3 -pthread'
+#print "CCCOM is:", env_with_err.subst('$CCCOM')
 
 objs = env_with_err.Object('src/art', 'src/art.c')
-test_runner = env_with_err.Program('test_runner', objs + ["tests/runner.c"], LIBS=["check"])
+test_runner = env_with_err.Program('test_runner',
+            objs + ["tests/runner.c"],
+            LIBS=["check"],
+            LIBPATH = ['/usr/lib', '/usr/local/lib'])
 Default(test_runner)


### PR DESCRIPTION
assume check was installed into /usr/local
use the default os ENV, do not strip it down.
add -Isrc and -I/usr/local/include via CPPPATH
allow overrides of CC, provide defaults for CCFLAGS,
add -L/usr/lib -L/usr/local/lib