### PR TITLE
compile a shared object, make test_runner depend on it, allow in tree…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
   - sudo ldconfig
   - popd
   - scons
-script: CK_TIMEOUT_MULTIPLIER=3 ./test_runner
+script: CK_TIMEOUT_MULTIPLIER=3 LD_LIBRARY_PATH=`pwd` ./test_runner

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ To build the test code successfully, do the following::
     $ scons
     $ ./test_runner
 
+Or, if you prefer, you can skip the installation of libcheck and the test
+will adapt to it being in the tree (leave out `make install`):
+
+     $ LD_LIBRARY_PATH=deps/check-0.9.8/src/.libs:. ./test_runner
+
+This build will produce a test_runner executable for testing and a shared_object 
+(libart.so on *NIX systems) for linking with.
+
 
 References
 ----------

--- a/SConstruct
+++ b/SConstruct
@@ -3,16 +3,19 @@ import os
 # assume check was installed into /usr/local/
 env_with_err = Environment(
 	ENV = os.environ,
-	CPPPATH = ['#/src', '/usr/local/include'])
+	CPPPATH = ['#/src', '#/deps/check-0.9.8/src', '/usr/local/include'])
+
 if "CC" in os.environ:
 	env_with_err["CC"] = os.environ["CC"]
 if "CCFLAGS" not in os.environ:
 	env_with_err["CCFLAGS"] = '-g -std=c99 -D_GNU_SOURCE -Wall -Werror -O3'
+if "SHLINKFLAGS" not in os.environ:
+	env_with_err['SHLINKFLAGS'] = '-shared -G'
 #print "CCCOM is:", env_with_err.subst('$CCCOM')
 
-objs = env_with_err.Object('src/art', 'src/art.c')
+shared_object = env_with_err.SharedLibrary('art', ['src/art.c'])
 test_runner = env_with_err.Program('test_runner',
-            objs + ["tests/runner.c"],
-            LIBS=["check"],
-            LIBPATH = ['/usr/lib', '/usr/local/lib'])
-Default(test_runner)
+            ["tests/runner.c"],
+            LIBS=["check", "art"],
+            LIBPATH = ['#', '#/deps/check-0.9.8/src/.libs', '/usr/lib', '/usr/local/lib'])
+Default(shared_object, test_runner)

--- a/SConstruct
+++ b/SConstruct
@@ -10,7 +10,7 @@ if "CC" in os.environ:
 if "CCFLAGS" not in os.environ:
 	env_with_err["CCFLAGS"] = '-g -std=c99 -D_GNU_SOURCE -Wall -Werror -O3'
 if "SHLINKFLAGS" not in os.environ:
-	env_with_err['SHLINKFLAGS'] = '-shared -G'
+	env_with_err['SHLINKFLAGS'] = '-shared'
 #print "CCCOM is:", env_with_err.subst('$CCCOM')
 
 shared_object = env_with_err.SharedLibrary('art', ['src/art.c'])


### PR DESCRIPTION
… check depends

Heyya, Armon.

We are going to use libart for a new project here at Circonus but we have some build tweaks to auto-create a shared object and to be able to use check in-tree.

Let me know what you think about merging this or if you think there should be another approach.

Thanks,