### PR TITLE
reorder elements in art_node to eliminate space inflation

### DIFF
--- a/src/art.h
+++ b/src/art.h
@@ -31,9 +31,9 @@ typedef int(*art_callback)(void *data, const unsigned char *key, uint32_t key_le
  * of all the various node sizes
  */
 typedef struct {
+    uint32_t partial_len;
     uint8_t type;
     uint8_t num_children;
-    uint32_t partial_len;
     unsigned char partial[MAX_PREFIX_LEN];
 } art_node;
 


### PR DESCRIPTION
The offset of partial_len is aligned at Byte 4 so there are two bytes of gap between num_children and partial_len. This inflates the size of struct art_node by 2 and it affects all the other node types.