### PR TITLE
support a art_insert_no_replace API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .sconsign.dblite
 *~
 test_runner
+src/libart.so

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+CC=gcc
+LD=gcc
+PREFIX=/usr/local
+LIBDIR=$(PREFIX)/lib
+INCLUDEDIR=$(PREFIX)/include
+CFLAGS=-g -std=c99 -D_GNU_SOURCE -Wall -Werror -O3
+SHCFLAGS=$(CFLAGS) -fPIC
+SHLINKFLAGS=-shared
+
+all:	src/libart.so
+
+src/libart.so:	src/libart.o
+	$(LD) $(SHLINKFLAGS) -o $@ $<
+
+src/art.c:	src/art.h
+
+src/libart.o:	src/art.c
+	$(CC) $(SHCFLAGS) -o $@ -c $<
+
+install:	src/libart.so
+	mkdir -p $(DESTDIR)$(LIBDIR)
+	mkdir -p $(DESTDIR)$(INCLUDEDIR)
+	cp src/libart.so $(DESTDIR)$(LIBDIR)/libart.so
+	chmod 555 $(DESTDIR)$(LIBDIR)/libart.so
+	cp src/art.h $(DESTDIR)$(INCLUDEDIR)/art.h
+	chmod 444 $(DESTDIR)$(INCLUDEDIR)/art.h

--- a/src/art.h
+++ b/src/art.h
@@ -129,15 +129,26 @@ inline uint64_t art_size(art_tree *t) {
 #endif
 
 /**
- * Inserts a new value into the ART tree
- * @arg t The tree
- * @arg key The key
- * @arg key_len The length of the key
- * @arg value Opaque value.
- * @return NULL if the item was newly inserted, otherwise
+ * inserts a new value into the art tree
+ * @arg t the tree
+ * @arg key the key
+ * @arg key_len the length of the key
+ * @arg value opaque value.
+ * @return null if the item was newly inserted, otherwise
  * the old value pointer is returned.
  */
 void* art_insert(art_tree *t, const unsigned char *key, int key_len, void *value);
+
+/**
+ * inserts a new value into the art tree (not replacing)
+ * @arg t the tree
+ * @arg key the key
+ * @arg key_len the length of the key
+ * @arg value opaque value.
+ * @return null if the item was newly inserted, otherwise
+ * the old value pointer is returned.
+ */
+void* art_insert_no_replace(art_tree *t, const unsigned char *key, int key_len, void *value);
 
 /**
  * Deletes a value from the ART tree


### PR DESCRIPTION
This is an alternative for of art_insert that will still return the existing entry, but not replace it.