### PR TITLE
docs: fix simple typo, occured -> occurred

### DIFF
--- a/deps/check-0.9.8/src/check.h
+++ b/deps/check-0.9.8/src/check.h
@@ -229,7 +229,7 @@ static void __testname (int _i CK_ATTRIBUTE_UNUSED)\
    FIXME:   strcmp (str1, str2) due to excessive string length. */
 #define fail_if(expr, ...)\
         _fail_unless(!(expr), __FILE__, __LINE__,\
-        "Failure '"#expr"' occured" , ## __VA_ARGS__, NULL)
+        "Failure '"#expr"' occurred" , ## __VA_ARGS__, NULL)
 
 /* Always fail */
 #define fail(...) _fail_unless(0, __FILE__, __LINE__, "Failed" , ## __VA_ARGS__, NULL)
@@ -306,9 +306,9 @@ int CK_EXPORT tr_rtype (TestResult *tr);
 enum ck_result_ctx CK_EXPORT tr_ctx (TestResult *tr); 
 /* Failure message */
 const char * CK_EXPORT tr_msg (TestResult *tr);
-/* Line number at which failure occured */
+/* Line number at which failure occurred */
 int CK_EXPORT tr_lno (TestResult *tr);
-/* File name at which failure occured */
+/* File name at which failure occurred */
 const char * CK_EXPORT tr_lfile (TestResult *tr);
 /* Test case in which unit test was run */
 const char * CK_EXPORT tr_tcname (TestResult *tr);

--- a/deps/check-0.9.8/src/check_impl.h
+++ b/deps/check-0.9.8/src/check_impl.h
@@ -66,7 +66,7 @@ typedef struct TestStats {
 struct TestResult {
   enum test_result rtype;     /* Type of result */
   enum ck_result_ctx ctx;     /* When the result occurred */
-  char *file;    /* File where the test occured */
+  char *file;    /* File where the test occurred */
   int line;      /* Line number where the test occurred */
   int iter;      /* The iteration value for looping tests */
   const char *tcname;  /* Test case that generated the result */


### PR DESCRIPTION
There is a small typo in deps/check-0.9.8/src/check.h, deps/check-0.9.8/src/check_impl.h.

Should read `occurred` rather than `occured`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md